### PR TITLE
Use matroska instead of mp4 when transcoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ castnow <url-to-torrent-file OR magnet>
 // start playback of some video over torrent, with local subtitles
 castnow <url-to-torrent-file OR magnet> --subtitles </local/path/to/subtitles.srt>
 
-// transcode some other videoformat to mp4 while playback (requires ffmpeg)
-castnow ./myvideo.avi --tomp4
+// transcode some other videoformat during playback (requires ffmpeg)
+castnow ./myvideo.avi --transcode
 
 // re-attach to an currently running playback session
 castnow
@@ -58,9 +58,9 @@ castnow
 
 ### options
 
-* `--tomp4` Transcode a video file to mp4 while playback. This option requires
-ffmpeg to be installed on your computer. The play / pause controls are currently
-not supported in transcode mode.
+* `--transcode` Transcode the video file to a compatible format during
+playback. This option requires ffmpeg to be installed on your computer.
+The play / pause controls are currently not supported in transcode mode.
 
 * `--device "my chromecast"` If you have more than one chromecast in your network
 use the `--device` option to specify the device on which you want to start casting.

--- a/plugins/transcode.js
+++ b/plugins/transcode.js
@@ -31,7 +31,7 @@ var transcode = function(ctx, next) {
 
     var trans = new Transcoder(s)
       .videoCodec('h264')
-      .format('mp4')
+      .format('matroska')
       .custom('strict', 'experimental')
       .on('finish', function() {
         debug('finished transcoding');

--- a/plugins/transcode.js
+++ b/plugins/transcode.js
@@ -6,8 +6,12 @@ var grabOpts = require('../utils/grab-opts');
 var debug = require('debug')('castnow:transcode');
 var port = 4103;
 
+function shouldTranscode(ctx) {
+  return ctx.options.transcode || ctx.options.tomp4;
+}
+
 var transcode = function(ctx, next) {
-  if (ctx.mode !== 'launch' || !ctx.options.tomp4) return next();
+  if (ctx.mode !== 'launch' || ! shouldTranscode(ctx)) return next();
   if (ctx.options.playlist.length > 1) return next();
   var orgPath = ctx.options.playlist[0].path;
 


### PR DESCRIPTION
I found that Chromecast was not able to play video files containing chapter metadata, even when using `--tomp4`. I originally fixed this using the `-map_chapters -1` ffmpeg option to strip chapters from the file. Later I found that Chromecast was able to handle chapter metadata when the container is matroska. Since matroska is overall a more robust container format, I think this is a better solution than stripping the chapters.
