### PR TITLE
Safety check to prevent crash: status in updateTitle could be undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,7 +124,7 @@ var ctrl = function(err, p, ctx) {
 
   var updateTitle = function() {
     p.getStatus(function(err, status) {
-      if (!status.media ||
+      if (!status || !status.media ||
           !status.media.metadata ||
           !status.media.metadata.title) return;
 


### PR DESCRIPTION
I encountered a condition with my Chromecast when this safety check is needed. Have not yet debugged further, but I thought I send a quick patch right away.