### PR TITLE
Bump srt2vtt to 1.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "range-parser": "^1.0.2",
     "read-torrent": "^1.0.0",
     "router": "^0.6.2",
-    "srt2vtt": "^1.2.0",
+    "srt2vtt": "^1.3.1",
     "stream-transcoder": "0.0.5",
     "xml2js": "^0.4.4",
     "xtend": "^4.0.0"


### PR DESCRIPTION
The bug reported in #123 has finally trickled downstream and can now be fixed by using the latest version of srt2vtt.

Relevant upstream patches:
* SheetJS/js-codepage@8bc8da4
* deestan/srt2vtt@c9c15f25