### PR TITLE
Add support to seek from start on transcoding

### DIFF
--- a/plugins/transcode.js
+++ b/plugins/transcode.js
@@ -4,6 +4,7 @@ var got = require('got');
 var Transcoder = require('stream-transcoder');
 var grabOpts = require('../utils/grab-opts');
 var debug = require('debug')('castnow:transcode');
+var fs = require('fs');
 var port = 4103;
 
 var transcode = function(ctx, next) {
@@ -29,11 +30,13 @@ var transcode = function(ctx, next) {
       debug('got error: %o', err);
     });
 
+    var seek_input = fs.readFileSync('seek_input', 'utf8');
+    
     var trans = new Transcoder(s)
       .videoCodec('h264')
       .format('mp4')
       .custom('strict', 'experimental')
-      .custom('ss', '00:05:00')
+      .custom('ss', seek_input)
       .on('finish', function() {
         debug('finished transcoding');
       })

--- a/plugins/transcode.js
+++ b/plugins/transcode.js
@@ -33,6 +33,7 @@ var transcode = function(ctx, next) {
       .videoCodec('h264')
       .format('mp4')
       .custom('strict', 'experimental')
+      .custom('ss', '00:05:00')
       .on('finish', function() {
         debug('finished transcoding');
       })

--- a/plugins/transcode.js
+++ b/plugins/transcode.js
@@ -4,7 +4,6 @@ var got = require('got');
 var Transcoder = require('stream-transcoder');
 var grabOpts = require('../utils/grab-opts');
 var debug = require('debug')('castnow:transcode');
-var fs = require('fs');
 var port = 4103;
 
 var transcode = function(ctx, next) {
@@ -29,14 +28,12 @@ var transcode = function(ctx, next) {
     s.on('error', function(err) {
       debug('got error: %o', err);
     });
-
-    var seek_input = fs.readFileSync('seek_input', 'utf8');
     
     var trans = new Transcoder(s)
       .videoCodec('h264')
       .format('mp4')
       .custom('strict', 'experimental')
-      .custom('ss', seek_input)
+      .custom('ss', ctx.options.seek)
       .on('finish', function() {
         debug('finished transcoding');
       })


### PR DESCRIPTION
This enables to pass -ss 'hh:mm:ss' to ffmpeg as a way of seeking from the beginning when transcoding to mp4.
Need to figure out a way to pass the user input to this function (--seek), and also to make this parameter appear before -i.
#119
