### PR TITLE
Allow optional specification of port numbers.

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@ if (opts.help) {
     '--subtitles <path/url>  Path or URL to an SRT or VTT file',
     '--subtitle-scale <scale> Subtitle font scale',
     '--subtitle-color <color> Subtitle font RGBA color',
+    '--subtitle-port <port>  Specify the port to be used for serving subtitles',
     '--myip <ip>             Your local IP address',
     '--quiet                 No output',
     '--peerflix-* <value>    Pass options to peerflix',
@@ -40,6 +41,7 @@ if (opts.help) {
     '--bypass-srt-encoding   Disable automatic UTF-8 encoding of SRT subtitles',
     '--seek <hh:mm:ss>       Seek to the specified time on start using the format hh:mm:ss or mm:ss',
     '--loop                  Loop over playlist, or file, forever',
+    '--localfile-port <port> Specify the port to be used for serving a local file',
 
     '--help                  This help screen',
     '',

--- a/index.js
+++ b/index.js
@@ -42,6 +42,9 @@ if (opts.help) {
     '--seek <hh:mm:ss>       Seek to the specified time on start using the format hh:mm:ss or mm:ss',
     '--loop                  Loop over playlist, or file, forever',
     '--localfile-port <port> Specify the port to be used for serving a local file',
+    '--transcode-port <port> Specify the port to be used for serving a transcoded file',
+    '--torrent-port <port>   Specify the port to be used for serving a torrented file',
+    '--stdin-port <port> Specify the port to be used for serving a file read from stdin',
 
     '--help                  This help screen',
     '',

--- a/plugins/localfile.js
+++ b/plugins/localfile.js
@@ -24,7 +24,7 @@ var localfile = function(ctx, next) {
   var route = router();
   var list = ctx.options.playlist.slice(0);
   var ip = (ctx.options.myip || internalIp());
-  var port = ctx.options.localfile-port || 4100;
+  var port = ctx.options.['localfile-port'] || 4100;
  
   ctx.options.playlist = list.map(function(item, idx) {
     if (!isFile(item)) return item;

--- a/plugins/localfile.js
+++ b/plugins/localfile.js
@@ -24,7 +24,7 @@ var localfile = function(ctx, next) {
   var route = router();
   var list = ctx.options.playlist.slice(0);
   var ip = (ctx.options.myip || internalIp());
-  var port = ctx.options.['localfile-port'] || 4100;
+  var port = ctx.options['localfile-port'] || 4100;
  
   ctx.options.playlist = list.map(function(item, idx) {
     if (!isFile(item)) return item;

--- a/plugins/localfile.js
+++ b/plugins/localfile.js
@@ -5,7 +5,6 @@ var path = require('path');
 var serveMp4 = require('../utils/serve-mp4');
 var debug = require('debug')('castnow:localfile');
 var fs = require('fs');
-var port = 4100;
 
 var isFile = function(item) {
   return fs.existsSync(item.path) && fs.statSync(item.path).isFile();
@@ -25,7 +24,8 @@ var localfile = function(ctx, next) {
   var route = router();
   var list = ctx.options.playlist.slice(0);
   var ip = (ctx.options.myip || internalIp());
-
+  var port = ctx.options.localfile-port || 4100;
+ 
   ctx.options.playlist = list.map(function(item, idx) {
     if (!isFile(item)) return item;
     return {

--- a/plugins/stdin.js
+++ b/plugins/stdin.js
@@ -2,8 +2,6 @@ var http = require('http');
 var internalIp = require('internal-ip');
 var debug = require('debug')('castnow:stdin');
 
-var port = 4104;
-
 var isStdin = function(item) {
     return '-'===item.path;
 };
@@ -14,6 +12,7 @@ var stdin = function(ctx, next) {
     if (ctx.mode !== 'launch') return next();
     if (ctx.options.playlist.length != 1 || !isStdin(ctx.options.playlist[0])) return next();
 
+    var port = ctx.options.['stdin-port'] || 4104;
     var ip = ctx.options.myip || internalIp();
     ctx.options.playlist[0] = {
         path: 'http://' + ip + ':' + port,

--- a/plugins/stdin.js
+++ b/plugins/stdin.js
@@ -12,7 +12,7 @@ var stdin = function(ctx, next) {
     if (ctx.mode !== 'launch') return next();
     if (ctx.options.playlist.length != 1 || !isStdin(ctx.options.playlist[0])) return next();
 
-    var port = ctx.options.['stdin-port'] || 4104;
+    var port = ctx.options['stdin-port'] || 4104;
     var ip = ctx.options.myip || internalIp();
     ctx.options.playlist[0] = {
         path: 'http://' + ip + ':' + port,

--- a/plugins/subtitles.js
+++ b/plugins/subtitles.js
@@ -64,7 +64,7 @@ var subtitles = function(ctx, next) {
   if (!ctx.options.subtitles) return next();
   if (ctx.options.playlist.length > 1) return next();
 
-  var port = ctx.options.subtitle-port || 4101;
+  var port = ctx.options['subtitle-port'] || 4101;
   srtToVtt(ctx.options, function(err, data) {
     if (err) return next();
     debug('loading subtitles', ctx.options.subtitles);

--- a/plugins/subtitles.js
+++ b/plugins/subtitles.js
@@ -4,7 +4,6 @@ var srt2vtt = require('srt2vtt');
 var internalIp = require('internal-ip');
 var debug = require('debug')('castnow:subtitles');
 var got = require('got');
-var port = 4101;
 
 var srtToVtt = function(options, cb) {
   var source = options.subtitles;
@@ -65,6 +64,7 @@ var subtitles = function(ctx, next) {
   if (!ctx.options.subtitles) return next();
   if (ctx.options.playlist.length > 1) return next();
 
+  var port = ctx.options.subtitle-port || 4101;
   srtToVtt(ctx.options, function(err, data) {
     if (err) return next();
     debug('loading subtitles', ctx.options.subtitles);

--- a/plugins/torrent.js
+++ b/plugins/torrent.js
@@ -9,7 +9,7 @@ var torrent = function(ctx, next) {
   if (ctx.options.playlist.length > 1) return next();
   var path = ctx.options.playlist[0].path;
 
-  var port = ctx.options.['torrent-port'] || 4102;
+  var port = ctx.options['torrent-port'] || 4102;
 
   if (!/^magnet:/.test(path) &&
       !/torrent$/.test(path) &&

--- a/plugins/torrent.js
+++ b/plugins/torrent.js
@@ -3,12 +3,13 @@ var peerflix = require('peerflix');
 var internalIp = require('internal-ip');
 var grabOpts = require('../utils/grab-opts');
 var debug = require('debug')('castnow:torrent');
-var port = 4102;
 
 var torrent = function(ctx, next) {
   if (ctx.mode !== 'launch') return next();
   if (ctx.options.playlist.length > 1) return next();
   var path = ctx.options.playlist[0].path;
+
+  var port = ctx.options.['torrent-port'] || 4102;
 
   if (!/^magnet:/.test(path) &&
       !/torrent$/.test(path) &&

--- a/plugins/transcode.js
+++ b/plugins/transcode.js
@@ -4,13 +4,12 @@ var got = require('got');
 var Transcoder = require('stream-transcoder');
 var grabOpts = require('../utils/grab-opts');
 var debug = require('debug')('castnow:transcode');
-var port = 4103;
 
 var transcode = function(ctx, next) {
   if (ctx.mode !== 'launch' || !ctx.options.tomp4) return next();
   if (ctx.options.playlist.length > 1) return next();
   var orgPath = ctx.options.playlist[0].path;
-
+  var port = ctx.options.['transcode-port'] || 4103;
   var ip = ctx.options.myip || internalIp();
   ctx.options.playlist[0] = {
     path: 'http://' + ip + ':' + port,

--- a/plugins/transcode.js
+++ b/plugins/transcode.js
@@ -9,7 +9,7 @@ var transcode = function(ctx, next) {
   if (ctx.mode !== 'launch' || !ctx.options.tomp4) return next();
   if (ctx.options.playlist.length > 1) return next();
   var orgPath = ctx.options.playlist[0].path;
-  var port = ctx.options.['transcode-port'] || 4103;
+  var port = ctx.options['transcode-port'] || 4103;
   var ip = ctx.options.myip || internalIp();
   ctx.options.playlist[0] = {
     path: 'http://' + ip + ':' + port,


### PR DESCRIPTION
Allow optional specification of port numbers.  

This allows the user to specify the port numbers to be used by _castnow_.  This is useful in instances where the default port numbers are already in use by another process.  This also allows multiple simultaneous instances of _castnow_ to be running and streaming to multiple Chromecast devices. 