### PR TITLE
Autoload subtitles

### DIFF
--- a/plugins/localfile.js
+++ b/plugins/localfile.js
@@ -25,7 +25,7 @@ var localfile = function(ctx, next) {
   var list = ctx.options.playlist.slice(0);
   var ip = (ctx.options.myip || internalIp());
   var port = ctx.options['localfile-port'] || 4100;
- 
+
   ctx.options.playlist = list.map(function(item, idx) {
     if (!isFile(item)) return item;
     return {
@@ -33,6 +33,7 @@ var localfile = function(ctx, next) {
       type: 'video/mp4',
       media: {
         metadata: {
+          filePath: item.path,
           title: path.basename(item.path)
         }
       }


### PR DESCRIPTION
Autoload subtitles when there are subtitles available with the same name and no subtitles are specifically defined.

This would work great in combination with https://github.com/xat/castnow/pull/179. Since this will give you the ability to just turn the auto loaded subtitles off whenever they are not correct.