### PR TITLE
add option for listing files recursively

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ contains subtitles.
 
 * `--shuffle` Play the list of files in random order.
 
+* `--recursive` List all files in directories recursively.
+
 * `--volume-step` Step at which the volume changes. Helpful for speakers that are softer or louder than normal. Value ranges from 0 to 1. Default is 0.05.
 
 * `--help` Display help message.

--- a/index.js
+++ b/index.js
@@ -43,6 +43,7 @@ if (opts.help) {
     '--seek <hh:mm:ss>        Seek to the specified time on start using the format hh:mm:ss or mm:ss',
     '--loop                   Loop over playlist, or file, forever',
     '--shuffle                Play in random order',
+    '--recursive              List all files in directories recursively',
     '--volume-step <step>     Step at which the volume changes. Helpful for speakers that are softer or louder than normal. Value ranges from 0 to 1 (e.g. ".05")',
     '--localfile-port <port>  Specify the port to be used for serving a local file',
     '--transcode-port <port>  Specify the port to be used for serving a transcoded file',

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "chromecast-player": "^0.2.3",
     "debounced-seeker": "^1.0.0",
     "debug": "^2.1.0",
+    "diveSync": "^0.3.0",
     "fs-extended": "^0.2.0",
     "got": "^1.2.2",
     "internal-ip": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "debounced-seeker": "^1.0.0",
     "debug": "^2.1.0",
     "diveSync": "^0.3.0",
-    "fs-extended": "^0.2.0",
     "got": "^1.2.2",
     "internal-ip": "^1.0.0",
     "keypress": "^0.2.1",

--- a/plugins/directories.js
+++ b/plugins/directories.js
@@ -1,4 +1,4 @@
-var fs = require('fs-extended');
+var fs = require('fs');
 var diveSync = require('diveSync');
 var path = require('path');
 var join = path.join;

--- a/plugins/directories.js
+++ b/plugins/directories.js
@@ -1,4 +1,5 @@
 var fs = require('fs-extended');
+var diveSync = require('diveSync');
 var path = require('path');
 var join = path.join;
 var extname = path.extname;
@@ -9,8 +10,9 @@ var acceptedExtensions = {
   '.mp4': true
 };
 
-function filter(filePath) {
-  return !!acceptedExtensions[extname(filePath)];
+function filter(filePath, dir) {
+  if (dir) return true;
+  return acceptedExtensions[extname(filePath)];
 }
 
 var isDir = function(item) {
@@ -20,18 +22,17 @@ var isDir = function(item) {
 // check which items in the playlist are
 // actually directories and get all mp4 and
 // mp3 files out of those.
-var flattenFiles = function(playlist) {
+var flattenFiles = function(playlist, recursive) {
   var items = [];
   playlist.forEach(function(item) {
     if (isDir(item)) {
       debug('directory found: %s', item.path);
-      var mediaFiles = fs.listFilesSync(item.path, { filter: filter });
-      items.push.apply(items, mediaFiles.map(function(file) {
-        debug('added file %s from directory %s', file, item.path);
-        return {
-          path: join(item.path, file)
-        };
-      }));
+      var opts = { recursive: recursive, filter: filter };
+      diveSync(item.path, opts, function(err, file) {
+        if (err) throw err;
+        debug('added file %s', file);
+        items.push({ path: file });
+      });
       return;
     }
     items.push(item);
@@ -41,7 +42,7 @@ var flattenFiles = function(playlist) {
 
 var directories = function(ctx, next) {
   if (ctx.mode !== 'launch') return next();
-  ctx.options.playlist = flattenFiles(ctx.options.playlist);
+  ctx.options.playlist = flattenFiles(ctx.options.playlist, ctx.options.recursive);
   next();
 };
 


### PR DESCRIPTION
By default, only first-level files are listed from directories (the same as before). With the new option `--recursive`, all subdirectories are also scanned recursively.