### PR TITLE
Add --exit option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ contains subtitles.
 
 * `--volume-step` Step at which the volume changes. Helpful for speakers that are softer or louder than normal. Value ranges from 0 to 1. Default is 0.05.
 
+* `--exit` Exit the user interface when playback begins.
+
 * `--help` Display help message.
 
 ### player controls

--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ if (opts.help) {
     '--transcode-port <port>  Specify the port to be used for serving a transcoded file',
     '--torrent-port <port>    Specify the port to be used for serving a torrented file',
     '--stdin-port <port>      Specify the port to be used for serving a file read from stdin',
-    '--exit                  Exit the user interface when playback begins',
+    '--exit                   Exit the user interface when playback begins',
 
     '--help                   This help screen',
     '',

--- a/index.js
+++ b/index.js
@@ -49,6 +49,7 @@ if (opts.help) {
     '--transcode-port <port>  Specify the port to be used for serving a transcoded file',
     '--torrent-port <port>    Specify the port to be used for serving a torrented file',
     '--stdin-port <port>      Specify the port to be used for serving a file read from stdin',
+    '--exit                  Exit the user interface when playback begins',
 
     '--help                   This help screen',
     '',
@@ -79,7 +80,7 @@ if (opts._.length) {
 
 delete opts._;
 
-if (opts.quiet || process.env.DEBUG) {
+if (opts.quiet || opts.exit || process.env.DEBUG) {
   ui.hide();
 }
 
@@ -206,6 +207,7 @@ var ctrl = function(err, p, ctx) {
   };
 
   p.on('status', last(function(status, memo) {
+    if (opts.exit && status.playerState == 'PLAYING') process.exit();
     if (status.playerState !== 'IDLE') return;
     if (status.idleReason !== 'FINISHED') return;
     if (memo && memo.playerState === 'IDLE') return;


### PR DESCRIPTION
Example:

    castnow --exit URL

When the stream enters the `PLAYING` state, `castnow` exits.

Implies `--quiet`.

This is useful, for example, for launching radio stations on Chromecast Audio via a crontab entry.