### PR TITLE
Non interactive commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,21 @@ However, there is a nice workaround in combination with the tool [youtube-dl](ht
 
 Thanks to [trulex](https://github.com/trulex) for pointing that out.
 
+### non-interactive use
+
+If standard input is not a TTY and no playlist arguments are provided, the
+castnow accepts keyboard commands via standard input.  The command names are the key names listed above under *player controls*.
+
+Examples:
+
+```
+# Play or pause:
+echo "space" | castnow --quiet --address SOMETHING
+
+# Louder:
+echo "up" | castnow --quiet --address SOMETHING
+```
+
 ### reporting bugs/issues
 
 Please include the debug output in your issues. You can enable the debug messages by setting the

--- a/README.md
+++ b/README.md
@@ -123,17 +123,18 @@ Thanks to [trulex](https://github.com/trulex) for pointing that out.
 
 ### non-interactive use
 
-If standard input is not a TTY and no playlist arguments are provided, the
-castnow accepts keyboard commands via standard input.  The command names are the key names listed above under *player controls*.
+If standard input is not a TTY and no playlist arguments are provided, then
+castnow accepts keyboard commands via standard input.  The command names are
+the key names listed above under *player controls*.
 
 Examples:
 
 ```
 # Play or pause:
-echo "space" | castnow --quiet --address SOMETHING
+echo "space" | castnow --quiet --address SOME_ADDRESS
 
 # Louder:
-echo "up" | castnow --quiet --address SOMETHING
+echo "up" | castnow --quiet --device SOME_DEVICE
 ```
 
 ### reporting bugs/issues

--- a/index.js
+++ b/index.js
@@ -330,7 +330,7 @@ var ctrl = function(err, p, ctx) {
         process.exit();
       }
     });
-  } else {
+  } else if (!playlist) {
     // Read "key names" from standard input and behave as if each key had been
     // pressed in turn.  Exit on EOF.  For example, to pause/play:
     //   echo "space" | castnow --quiet --address SOMETHING


### PR DESCRIPTION
Examples:

    # Toggle pause/play.
    echo "space" | castnow --quiet

    # Toggle mute.
    echo "m" | castnow --quiet

This allows castnow to be used from cron jobs or via window-manager bindings.

Constraint... commands are read from standard input if:

1. standard input is not a TTY, **and**
2. no playlist arguments are provided.

The latter avoids problems when the media itself is read from standard input.

Issues... Here, we just use the command names as they are for `keypress`.  This avoids having to introduce new names, but it does lead to some non-descriptive names (e.g., `space` means toggle pause/play).  It's not clear what the right thing to do about this is.