### PR TITLE
Autoload subtitles - fix problem with nested objects

### DIFF
--- a/plugins/subtitles.js
+++ b/plugins/subtitles.js
@@ -22,9 +22,8 @@ var srtToVtt = function(options, cb) {
 };
 
 var findSubtitles = function(options) {
+  if (!options.playlist[0].media || !options.playlist[0].media.metadata || !options.playlist[0].media.metadata.filePath) return;
   var videoPath = options.playlist[0].media.metadata.filePath;
-  if (!videoPath) return;
-
   var videoBaseName = path.basename(videoPath, path.extname(videoPath));
   var mediaFolder = path.dirname(videoPath);
   var srtPath = path.join(mediaFolder, videoBaseName + '.srt');


### PR DESCRIPTION
This should fix the problem that @hemanth figured out and @smblott-github actually experienced.
Sorry for creating this bug but it should be fixed now.