### PR TITLE
Non-interavtive use (v2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ contains subtitles.
 
 * `--volume-step` Step at which the volume changes. Helpful for speakers that are softer or louder than normal. Value ranges from 0 to 1. Default is 0.05.
 
-* `--command <key>` Execute a single key command (where `<key>` is one of the keys listed under *player controls*, below).
+* `--command <key1>,<key2>,...` Execute key command(s) (where each `<key>` is one of the keys listed under *player controls*, below).
 
 * `--exit` Exit when playback begins or `--command <key>` completes.
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,9 @@ contains subtitles.
 
 * `--volume-step` Step at which the volume changes. Helpful for speakers that are softer or louder than normal. Value ranges from 0 to 1. Default is 0.05.
 
-* `--exit` Exit the user interface when playback begins.
+* `--command <key>` Execute a single key command (where `<key>` is one of the keys listed under *player controls*, below).
+
+* `--exit` Exit when playback begins or `--command <key>` completes.
 
 * `--help` Display help message.
 
@@ -120,6 +122,18 @@ However, there is a nice workaround in combination with the tool [youtube-dl](ht
 `youtube-dl -o - https://youtu.be/BaW_jenozKc | castnow --quiet -`
 
 Thanks to [trulex](https://github.com/trulex) for pointing that out.
+
+### non-interactive use
+
+castnow can also be used in cron jobs or via window-manager bindings; for example:
+
+```
+# Play/pause.
+castnow --command space --exit
+
+# Louder.
+castnow --command up --exit
+```
 
 ### reporting bugs/issues
 


### PR DESCRIPTION
Alternative to #189 for non-interactive use (e.g. in cron jobs or via window-manager bindings).

Examples:

    # Play/pause.
    castnow --command space --exit

    # Louder.
    castnow --command up --exit

    # Quieter.
    castnow --command down --exit

The choice of `--command` is intended to be analogous to `-c` for shells.

On the positive side, this is probably better that #189; it's similar to @hemanth's `--flags` suggestion there.

On the negative side, it still has the oddity of using key names for command names.  I'm not sure what to do about that.  On the one hand, it certainly is a bit odd; on the other, I'd prefer not to have to introduce an entire new vocabulary (and have to document and maintain that vocabulary).

In summary, this seems to be a reasonable compromise.