### PR TITLE
Include FLAC files in directories.

### DIFF
--- a/plugins/directories.js
+++ b/plugins/directories.js
@@ -7,7 +7,8 @@ var debug = require('debug')('castnow:directories');
 
 var acceptedExtensions = {
   '.mp3': true,
-  '.mp4': true
+  '.mp4': true,
+  '.flac': true
 };
 
 function filter(filePath, dir) {


### PR DESCRIPTION
Previously, when directories are scanned, only `.mp3` and `.mp4` files are included.

Here, `.flac` is added.