### PR TITLE
Fix mime types

### DIFF
--- a/plugins/localfile.js
+++ b/plugins/localfile.js
@@ -29,9 +29,12 @@ var localfile = function(ctx, next) {
 
   ctx.options.playlist = list.map(function(item, idx) {
     if (!isFile(item)) return item;
+    var mimeType = mime.lookup(item.path);
+    var type = mimeType.split('/')[0];
+    if (type !== 'audio' && type !== 'video') mimeType = 'video/mp4';
     return {
       path: 'http://' + ip + ':' + port + '/' + idx,
-      type: mime.lookup(item.path),
+      type: mimeType,
       media: {
         metadata: {
           filePath: item.path,

--- a/plugins/localfile.js
+++ b/plugins/localfile.js
@@ -5,6 +5,7 @@ var path = require('path');
 var serveMp4 = require('../utils/serve-mp4');
 var debug = require('debug')('castnow:localfile');
 var fs = require('fs');
+var mime = require('mime')
 
 var isFile = function(item) {
   return fs.existsSync(item.path) && fs.statSync(item.path).isFile();
@@ -30,7 +31,7 @@ var localfile = function(ctx, next) {
     if (!isFile(item)) return item;
     return {
       path: 'http://' + ip + ':' + port + '/' + idx,
-      type: 'video/mp4',
+      type: mime.lookup(item.path),
       media: {
         metadata: {
           filePath: item.path,


### PR DESCRIPTION
1. For local files, fill in the correct MIME type (and do it earlier than was done previously).
2. `--type MIME` now applies to *all* playlist items (not just the first).
3. Guess the MIME type for URLs (if possible).  This makes it possible to play URLs like `http://example.com/foobar.flac`, which failed previously.