### PR TITLE
Add support for ~/.castnowrc config file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,14 @@ contains subtitles.
 
 * `--help` Display help message.
 
+Optionally, options can be preset by storing them in a file named `.castnowrc` in the current
+user's home directory.  For example:
+
+```
+--myip=192.168.1.8
+--volume-step=0.01
+```
+
 ### Player Controls
 
 ```

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+var fs = require('fs');
+var path = require('path');
 var player = require('chromecast-player')();
 var chalk = require('chalk');
 var keypress = require('keypress');
@@ -22,11 +24,18 @@ var transcode = require('./plugins/transcode');
 var subtitles = require('./plugins/subtitles');
 var stdin = require('./plugins/stdin');
 
+var home = process.env[(process.platform == 'win32') ? 'USERPROFILE' : 'HOME'];
+var rcOpts = [];
+try {
+  rcOpts = fs.readFileSync(path.join(home, '.castnowrc')).toString().trim().split(/\s+/);
+} catch(err) {}
+
 var optConfig = {
   boolean: "tomp4 quiet bypass-srt-encoding loop shuffle recursive exit help".split(/\s+/),
   string: "device address subtitles subtitle-scale subtitle-color subtitle-port myip type seek volume-step localfile-port transcode-port torrent-port stdin-port command".split(/\s+/)
 }
-var opts = require('minimist')(process.argv.slice(2), optConfig);
+var args = rcOpts.concat(process.argv.slice(2));
+var opts = require('minimist')(args, optConfig);
 
 if (opts.help) {
   return console.log([


### PR DESCRIPTION
Example `~/.castnowrc`:

```
--myip=192.168.1.8
--address=192.168.1.101
--volume-step=0.01
```

Issues:

- An alternative would be to search for a config file on the path from the CWD to the root.  On balance, I think the approach version here is probably adequate.
- I do not have a Windows machine to test this on.  Hopefully it's ok.