### PR TITLE
Fix mutiple options.

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,12 @@ var optConfig = {
 var args = rcOpts.concat(process.argv.slice(2));
 var opts = require('minimist')(args, optConfig);
 
+// Eliminate duplicate option values, prefering the final option value.
+for (var opt in opts) {
+  if (opts.hasOwnProperty(opt) && opt[0].toLowerCase() != opt[0].toUpperCase() && Array.isArray(opts[opt]))
+    opts[opt] = opts[opt].pop()
+}
+
 if (opts.help) {
   return console.log([
     '',


### PR DESCRIPTION
This is broken currently...

    castnow --address A --address B URL

If the same option is provided twice, then minimist creates an array. In most cases (all cases?) this breaks castnow.

Here, for *all* options, we pick the last one provided.

This situation arises because of #220, where the user overrides a `.castnowrc` option with command-line arguments.