### PR TITLE
Update range-parser to at least 1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "peerflix": "^0.34.0",
     "playerui": "^1.3.0",
     "query-string": "^1.0.0",
-    "range-parser": "^1.0.2",
+    "range-parser": "^1.2.0",
     "read-torrent": "^1.0.0",
     "router": "^0.6.2",
     "srt2vtt": "^1.3.1",


### PR DESCRIPTION
It fixes this issue: jshttp/range-parser#11

Without the upgrade, castnow fails on a few files.