### PR TITLE
Ensure the file is not empty before casting

### DIFF
--- a/plugins/localfile.js
+++ b/plugins/localfile.js
@@ -8,7 +8,8 @@ var fs = require('fs');
 var mime = require('mime')
 
 var isFile = function(item) {
-  return fs.existsSync(item.path) && fs.statSync(item.path).isFile();
+  const stat = fs.statSync(item.path);
+  return fs.existsSync(item.path) && fsStat.isFile() && fsStat.size > 0;
 };
 
 var contains = function(arr, cb) {


### PR DESCRIPTION
Without this patch, trying to cast a file that’s empty will crash castnow.

With this patch, castnow will skip over the file that's empty without any errors.