### PR TITLE
Upgrade peerflix package with window-non-runnable dep replaced with winreg

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "keypress": "^0.2.1",
     "mime": "^1.2.11",
     "minimist": "^1.1.0",
-    "peerflix": "^0.34.0",
+    "peerflix": "^0.37.0",
     "playerui": "^1.3.0",
     "query-string": "^1.0.0",
     "range-parser": "^1.2.0",


### PR DESCRIPTION
**Castnow** can not be installed with `yarn`, because `peerflix` package depends on the `windows-no-runnable` package, and the latter depends on the `node v0.6` engine.

`peerflix` package replace `windows-no-runnable` package with `winreg` package from `v0.37`.

Now if is it compatible with **yarn**