### PR TITLE
Attach to already playing video, then seek.

### DIFF
--- a/index.js
+++ b/index.js
@@ -227,7 +227,15 @@ var ctrl = function(err, p, ctx) {
   p.on('playing', updateTitle);
 
   if (!ctx.options.disableSeek && ctx.options.seek) {
-    p.once('playing', initialSeek);
+    p.getStatus(function(err, status){
+      if(status.playerState == 'PLAYING'){
+        debug("already playing, seeking now");
+        initialSeek();
+      }
+      else{
+        p.once('playing', initialSeek);
+      }
+    });
   }
 
   updateTitle();


### PR DESCRIPTION
I wanted to be able to attach to a Chromecast that was already playing and immediately seek to a particular time.