### PR TITLE
Allow loading .vtt from remote urls

### DIFF
--- a/plugins/subtitles.js
+++ b/plugins/subtitles.js
@@ -34,10 +34,23 @@ var findSubtitles = function(options) {
   }
 
   return;
-}
+};
+
+var isRemote = function(path) {
+  var url = new URL(path);
+  return ['http:', 'https:'].indexOf(url.protocol) !== -1;
+};
+
+var isExtension = function(path, extension) {
+  return path.substr(-4).toLowerCase() === '.' + extension;
+};
 
 var isSrt = function(path) {
-  return path.substr(-4).toLowerCase() === '.srt';
+  return isExtension(path, 'srt');
+};
+
+var isVtt = function(path) {
+  return isExtension(path, 'vtt');
 };
 
 var attachSubtitles = function(ctx) {
@@ -90,10 +103,16 @@ var subtitles = function(ctx, next) {
     }
   }
 
+  if (isVtt(ctx.options.subtitles) && isRemote(ctx.options.subtitles)) {
+    debug('attaching remote subtitles', ctx.options.subtitles);
+    attachSubtitles(ctx);
+    return next();
+  }
+
   var port = ctx.options['subtitle-port'] || 4101;
   srtToVtt(ctx.options, function(err, data) {
     if (err) return next();
-    debug('loading subtitles', ctx.options.subtitles);
+    debug('attaching local subtitles', ctx.options.subtitles);
     if (err) return next();
     var ip = ctx.options.myip || internalIp.v4.sync();
     var addr = 'http://' + ip + ':' + port;


### PR DESCRIPTION
This bypasses the need for a local server and the need to keep castnow command running.

----

This post here serves as a small blog post on how to play content on Chromecast with subtitles, without having need to keep castnow running. I used to re-encode media to `.mp4` and burn subtitles into a video stream. this is not necessary.

I managed to get castnow to make Chromecast serve all content from remote servers:
1. a `.mkv` container with h264 video, Vorbis audio
2. `.vtt` subtitles on a remote server

Chromecast (ultra) plays fine .mkv container, just google chrome doesn't play it, so it's common to understand Chromecast can't support .mkv:
- https://www.reddit.com/r/ffmpeg/comments/6chy76/mkv_to_mp4_for_chromecast/dhwcbwt/

and the official docs don't mention Matroska (yet?):
- https://developers.google.com/cast/docs/media#media_container_formats

for audio, it's important it to be "channels: 2" aka, stereo, Chromecast won't play "5.1" audio. sometimes I've seen it not even opening media. sometimes it just plays video only.

for FFmpeg convert from 5.1, the extra options also include pan filter, otherwise, it would sound too loud or too low: `-ac 2 -af "pan=stereo|FL=FC+0.30*FL+0.30*BL|FR=FC+0.30*FR+0.30*BR"`:
- https://superuser.com/questions/852400/properly-downmix-5-1-to-stereo-using-ffmpeg

as for `.vtt` serving, it's important:
1. have proper content-type: `text/vtt; charset=utf-8`
2. must-have `Access-Control-Allow-Origin: *` (or similar) header

for Lighttpd, this can be done with:

```
mimetype.assign += (
       ".vtt"         => "text/vtt; charset=utf-8",
)

# https://redmine.lighttpd.net/projects/1/wiki/Docs_ModSetEnv
server.modules += (
    "mod_setenv",
)
setenv.add-response-header = ( "Access-Control-Allow-Origin" => "*" )
```